### PR TITLE
Improve docs and doctests

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -68,6 +68,7 @@ impl Board {
     ///
     /// # Example
     /// ```
+    /// use battleship::{Board, PlayerState};
     /// let mut board = Board::new();
     /// assert_eq!(board.player_state(), PlayerState::Setup);
     /// ```
@@ -172,6 +173,7 @@ impl Board {
     ///
     /// # Example
     /// ```
+    /// use battleship::Board;
     /// let mut board = Board::new();
     /// let result = board.place_ship("Carrier", (0, 0), true);
     /// assert!(result.is_ok());
@@ -228,8 +230,10 @@ impl Board {
     ///
     /// # Example
     /// ```
+    /// use battleship::Board;
+    /// use battleship::constants::GuessResult;
     /// let mut board = Board::new();
-    /// board.place_ship("Carrier", (0, 0), true);
+    /// board.place_ship("Carrier", (0, 0), true).unwrap();
     /// let result = board.guess((0, 0));
     /// assert_eq!(result.unwrap(), GuessResult::Hit);
     /// ```

--- a/src/cli_interface.rs
+++ b/src/cli_interface.rs
@@ -1,13 +1,16 @@
-// src/cli_interface.rs
 use crate::board::Board;
 use crate::interface::GameInterface;
 use std::io::{self, Write};
 
+/// Simple command line user interface implementation.
+///
+/// This implementation reads moves from standard input and prints
+/// the board and messages to standard output.
 pub struct CLIInterface;
 
 impl GameInterface for CLIInterface {
     fn get_move(&self, _board: &Board) -> (usize, usize) {
-        // For example, prompt the user for input like "A5" and convert it to coordinates.
+        // Prompt the user for input like "A5" and convert it to coordinates.
         print!("Enter your move (e.g., A5): ");
         io::stdout().flush().unwrap();
         let mut input = String::new();

--- a/src/embedded_interface.rs
+++ b/src/embedded_interface.rs
@@ -1,6 +1,10 @@
 use crate::board::Board;
 use crate::interface::GameInterface;
 
+/// Stub implementation of a user interface for embedded targets.
+///
+/// In a real embedded environment this would interface with
+/// hardware such as buttons and displays.
 pub struct EmbeddedInterface;
 
 impl GameInterface for EmbeddedInterface {

--- a/src/game_loop.rs
+++ b/src/game_loop.rs
@@ -2,11 +2,18 @@ use crate::board::Board;
 use crate::interface::GameInterface;
 use crate::constants::PlayerState;
 
+/// Available game modes.
 pub enum GameMode {
+    /// Human vs computer.
     SinglePlayer,
+    /// Two human players taking turns.
     Multiplayer,
 }
 
+/// Run a complete game using the provided user interface implementation.
+///
+/// The game loop handles alternating turns, displaying boards and
+/// checking for win conditions until one side has no ships remaining.
 pub fn run_game<T: GameInterface>(ui: T, mode: GameMode) {
     let mut player_board = Board::new();
     let mut opponent_board = Board::new();

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,7 +1,20 @@
 use crate::board::Board;
 
+/// Abstraction over user interaction for the Battleship game.
+///
+/// Different implementations can provide various ways of obtaining
+/// moves and displaying information, such as a command line interface
+/// or an embedded system display.
 pub trait GameInterface {
+    /// Request the next move from the player.
+    ///
+    /// The implementation is responsible for validating and parsing
+    /// any user input into board coordinates.
     fn get_move(&self, board: &Board) -> (usize, usize);
+
+    /// Render the current state of the provided board to the user.
     fn display_board(&self, board: &Board);
+
+    /// Show an informational message to the player.
     fn display_message(&self, message: &str);
 }

--- a/src/ship.rs
+++ b/src/ship.rs
@@ -35,6 +35,7 @@ impl Ship {
     ///
     /// # Example
     /// ```
+    /// use battleship::Ship;
     /// let carrier = Ship::new("Carrier", 5);
     /// assert_eq!(carrier.length(), 5);
     /// assert!(!carrier.is_placed());
@@ -79,6 +80,9 @@ impl Ship {
     ///
     /// # Examples
     /// ```
+    /// use battleship::Ship;
+    /// use battleship::constants::GuessResult;
+    /// use std::collections::HashSet;
     /// let mut ship = Ship::new("Destroyer", 2);
     /// ship.place(HashSet::from([(0,0), (0,1)])).unwrap();
     /// let result = ship.guess((0,0));


### PR DESCRIPTION
## Summary
- expand documentation for core interface components
- improve doc examples for `Board` and `Ship`
- document game loop and modes
- add comments to CLI and embedded interfaces

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6858b97543b08329b857f4c38a30d8c8