### PR TITLE
Restore CLI gameplay

### DIFF
--- a/battleship-cli/src/main.rs
+++ b/battleship-cli/src/main.rs
@@ -1,7 +1,53 @@
-use battleship_interface::cli::CLIInterface;
+use battleship_core::{Board, constants::PlayerState};
+use battleship_interface::{cli::CLIInterface, GameInterface};
+use battleship_player::probability;
 
 fn main() {
-    let _ui = CLIInterface;
-    println!("CLI game placeholder");
+    let ui = CLIInterface;
+    run_game(ui);
+}
+
+fn run_game<I: GameInterface>(ui: I) {
+    let mut player_board = Board::new();
+    let mut ai_board = Board::new();
+
+    player_board.randomly_place_fleet().unwrap();
+    ai_board.randomly_place_fleet().unwrap();
+
+    loop {
+        ui.display_board(&player_board);
+        ui.display_message("Your turn:");
+        let coord = ui.get_move(&player_board);
+
+        match ai_board.guess(coord) {
+            Ok(result) => ui.display_message(&format!("You: {}", result)),
+            Err(e) => {
+                ui.display_message(&format!("Error: {:?}", e));
+                continue;
+            }
+        }
+
+        if ai_board.player_state() == PlayerState::Dead {
+            ui.display_message("You won!");
+            break;
+        }
+
+        let ai_guess = probability::calc_pdf_and_guess(&player_board);
+        match player_board.guess(ai_guess) {
+            Ok(result) => ui.display_message(&format!("AI: {}", result)),
+            Err(e) => ui.display_message(&format!("AI Error: {:?}", e)),
+        }
+
+        if player_board.player_state() == PlayerState::Dead {
+            ui.display_message("AI won!");
+            break;
+        }
+    }
+
+    ui.display_message("Final boards:");
+    ui.display_message("AI board:");
+    ui.display_board(&ai_board);
+    ui.display_message("Player board:");
+    ui.display_board(&player_board);
 }
 


### PR DESCRIPTION
## Summary
- replace placeholder CLI main with simple game loop
- randomly place fleets for player and AI
- drive gameplay in the CLI

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_6858ceaf040c832985c3cec01da84c30