### PR TITLE
Add VS Code LLDB launch configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Cargo.lock
 Thumbs.db
 
 notes.txt
+!/.vscode/
+!/.vscode/launch.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,61 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'battleship-core'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=battleship-core"
+                ],
+                "filter": {
+                    "name": "battleship-core",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug executable 'battleship-cli'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--bin=battleship-cli",
+                    "--package=battleship-cli"
+                ],
+                "filter": {
+                    "name": "battleship-cli",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in executable 'battleship-cli'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bin=battleship-cli",
+                    "--package=battleship-cli"
+                ],
+                "filter": {
+                    "name": "battleship-cli",
+                    "kind": "bin"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add LLDB launch configurations for debugging library tests and the CLI binary
- allow `.vscode/launch.json` to be tracked

## Testing
- `cargo test --workspace --quiet` *(fails: doctests in battleship-core)*

------
https://chatgpt.com/codex/tasks/task_e_68599f5589a48329979c1356972d4d70