### PR TITLE
Fix move parsing and display both boards

### DIFF
--- a/battleship-cli/src/main.rs
+++ b/battleship-cli/src/main.rs
@@ -15,7 +15,10 @@ fn run_game<I: GameInterface>(ui: I) {
     ai_board.randomly_place_fleet().unwrap();
 
     loop {
-        ui.display_board(&player_board);
+        ui.display_message("Opponent board:");
+        ui.display_message(&ai_board.format_board(false));
+        ui.display_message("Your board:");
+        ui.display_message(&player_board.format_board(true));
         ui.display_message("Your turn:");
         let coord = ui.get_move(&player_board);
 
@@ -46,8 +49,8 @@ fn run_game<I: GameInterface>(ui: I) {
 
     ui.display_message("Final boards:");
     ui.display_message("AI board:");
-    ui.display_board(&ai_board);
+    ui.display_message(&ai_board.format_board(true));
     ui.display_message("Player board:");
-    ui.display_board(&player_board);
+    ui.display_message(&player_board.format_board(true));
 }
 

--- a/battleship-core/src/board.rs
+++ b/battleship-core/src/board.rs
@@ -298,6 +298,50 @@ impl Board {
         self.coordinates.difference(&self.guessed)
     }
 
+    /// Formats the board into a string. When `reveal_ships` is false the
+    /// underlying ship positions are hidden and only guesses are shown.
+    pub fn format_board(&self, reveal_ships: bool) -> String {
+        use std::fmt::Write as _;
+
+        let ships = if reveal_ships {
+            self.fleet.ship_coords(true, true)
+        } else {
+            HashSet::new()
+        };
+        let hits = self.fleet.hit_coords(true, true);
+
+        let mut out = String::new();
+        // header
+        out.push_str("   ");
+        for col in 1..=self.gridsize {
+            let _ = write!(out, " {} ", col);
+        }
+        out.push('\n');
+
+        // rows
+        for row in 0..self.gridsize {
+            let _ = write!(out, "{} ", (b'A' + row as u8) as char);
+            for col in 0..self.gridsize {
+                let coord = (row, col);
+                let icon = if self.guessed.contains(&coord) {
+                    if hits.contains(&coord) {
+                        Cell::Hit.icon()
+                    } else {
+                        Cell::Miss.icon()
+                    }
+                } else if reveal_ships && ships.contains(&coord) {
+                    Cell::Ship.icon()
+                } else {
+                    Cell::Empty.icon()
+                };
+                let _ = write!(out, " {} ", icon);
+            }
+            out.push('\n');
+        }
+
+        out
+    }
+
     // pub fn print_grid(&self) {
     //     let ships = self.fleet.ship_coords(true, true);
     //     let hits = self.fleet.hit_coords(true, true);
@@ -334,39 +378,7 @@ impl Board {
 
 impl fmt::Display for Board {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ships = self.fleet.ship_coords(true, true);
-        let hits = self.fleet.hit_coords(true, true);
-
-        // Print header
-        write!(f, "   ")?; // Initial space for row labels
-        for col in 1..=self.gridsize {
-            write!(f, " {} ", col)?;
-        }
-        writeln!(f)?;
-
-        // Print rows
-        for row in 0..self.gridsize {
-            // Print row letter
-            write!(f, "{} ", (b'A' + row as u8) as char)?;
-            for col in 0..self.gridsize {
-                let coord = (row, col);
-                let icon = if self.guessed.contains(&coord) {
-                    if hits.contains(&coord) {
-                        Cell::Hit.icon()
-                    } else {
-                        Cell::Miss.icon()
-                    }
-                } else if ships.contains(&coord) {
-                    Cell::Ship.icon()
-                } else {
-                    Cell::Empty.icon()
-                };
-                write!(f, " {} ", icon)?;
-            }
-            writeln!(f)?;
-        }
-
-        Ok(())
+        write!(f, "{}", self.format_board(true))
     }
 }
 

--- a/battleship-interface/src/cli.rs
+++ b/battleship-interface/src/cli.rs
@@ -10,14 +10,22 @@ pub struct CLIInterface;
 
 impl GameInterface for CLIInterface {
     fn get_move(&self, _board: &Board) -> (usize, usize) {
-        // Prompt the user for input like "A5" and convert it to coordinates.
         print!("Enter your move (e.g., A5): ");
         io::stdout().flush().unwrap();
         let mut input = String::new();
         io::stdin().read_line(&mut input).unwrap();
-        // Convert input to board coordinates (this is just a placeholder).
-        // You would include proper parsing and error handling.
-        (0, 0)
+        let input = input.trim().to_uppercase();
+        if input.len() < 2 {
+            return (0, 0);
+        }
+        let row_char = input.chars().next().unwrap();
+        let row = row_char as usize - b'A' as usize;
+        let col = input[1..].parse::<usize>().unwrap_or(1);
+        if row >= battleship_core::constants::GRID_SIZE || col == 0 || col > battleship_core::constants::GRID_SIZE {
+            (0, 0)
+        } else {
+            (row, col - 1)
+        }
     }
 
     fn display_board(&self, board: &Board) {


### PR DESCRIPTION
## Summary
- parse coordinates in CLI properly
- add `format_board` method to show boards with or without ships
- show both boards each turn in CLI

## Testing
- `cargo test` *(fails: doctest failed)*

------
https://chatgpt.com/codex/tasks/task_e_6859aa20fad88329b471fa77c5e7d626