### PR TITLE
Add move suggestion feature to CLI

### DIFF
--- a/battleship-cli/src/main.rs
+++ b/battleship-cli/src/main.rs
@@ -7,7 +7,7 @@ fn main() {
     run_game(ui);
 }
 
-fn run_game<I: GameInterface>(ui: I) {
+fn run_game(ui: CLIInterface) {
     let mut player_board = Board::new();
     let mut ai_board = Board::new();
 
@@ -20,7 +20,8 @@ fn run_game<I: GameInterface>(ui: I) {
         ui.display_message("Your board:");
         ui.display_message(&player_board.format_board(true));
         ui.display_message("Your turn:");
-        let coord = ui.get_move(&player_board);
+        let suggestion = probability::calc_pdf_and_guess(&ai_board);
+        let coord = ui.get_move_with_default(&ai_board, suggestion);
 
         match ai_board.guess(coord) {
             Ok(result) => ui.display_message(&format!("You: {}", result)),

--- a/battleship-interface/src/cli.rs
+++ b/battleship-interface/src/cli.rs
@@ -37,3 +37,28 @@ impl GameInterface for CLIInterface {
     }
 }
 
+impl CLIInterface {
+    pub fn get_move_with_default(&self, _board: &Board, default: (usize, usize)) -> (usize, usize) {
+        let row_char = (b'A' + default.0 as u8) as char;
+        let col = default.1 + 1;
+        print!("Enter your move (e.g., {}{}): ", row_char, col);
+        io::stdout().flush().unwrap();
+        let mut input = String::new();
+        io::stdin().read_line(&mut input).unwrap();
+        let input = input.trim().to_uppercase();
+        if input.is_empty() {
+            return default;
+        }
+        if input.len() < 2 {
+            return (0, 0);
+        }
+        let row_char = input.chars().next().unwrap();
+        let row = row_char as usize - b'A' as usize;
+        let col = input[1..].parse::<usize>().unwrap_or(1);
+        if row >= battleship_core::constants::GRID_SIZE || col == 0 || col > battleship_core::constants::GRID_SIZE {
+            (0, 0)
+        } else {
+            (row, col - 1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- suggest the best move using probability calculations
- allow user to accept suggestion by pressing Enter
- show suggestion in the move prompt

## Testing
- `cargo check -q`
- `cargo test -q` *(fails: doctest compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859b55edc4c8329bbaaf32f1d0f81f3