### PR TITLE
Decouple interface with BoardView trait

### DIFF
--- a/battleship-common/src/board.rs
+++ b/battleship-common/src/board.rs
@@ -1,0 +1,3 @@
+pub trait BoardView: std::fmt::Display {
+    fn grid_size(&self) -> usize;
+}

--- a/battleship-common/src/lib.rs
+++ b/battleship-common/src/lib.rs
@@ -1,2 +1,5 @@
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
+pub mod board;
+pub use board::BoardView;
+

--- a/battleship-core/Cargo.toml
+++ b/battleship-core/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 rand = "0.8"
 array-init = "2.0"
+battleship-common = { path = "../battleship-common" }
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/battleship-core/src/board.rs
+++ b/battleship-core/src/board.rs
@@ -382,3 +382,9 @@ impl fmt::Display for Board {
     }
 }
 
+impl battleship_common::BoardView for Board {
+    fn grid_size(&self) -> usize {
+        self.gridsize
+    }
+}
+

--- a/battleship-core/src/lib.rs
+++ b/battleship-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ship;
 pub mod constants;
 
 pub use board::Board;
+pub use battleship_common::BoardView;
 pub use fleet::Fleet;
 pub use ship::Ship;
 pub use constants::{GRID_SIZE, PlayerState, GuessResult, GuessError, GameplayError, Cell};

--- a/battleship-interface/Cargo.toml
+++ b/battleship-interface/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-battleship-core = { path = "../battleship-core" }
+battleship-common = { path = "../battleship-common" }
 
 [dev-dependencies]
 

--- a/battleship-interface/src/cli.rs
+++ b/battleship-interface/src/cli.rs
@@ -1,4 +1,4 @@
-use battleship_core::Board;
+use battleship_common::BoardView;
 use crate::GameInterface;
 use std::io::{self, Write};
 
@@ -9,7 +9,7 @@ use std::io::{self, Write};
 pub struct CLIInterface;
 
 impl GameInterface for CLIInterface {
-    fn get_move(&self, _board: &Board) -> (usize, usize) {
+    fn get_move(&self, board: &dyn BoardView) -> (usize, usize) {
         print!("Enter your move (e.g., A5): ");
         io::stdout().flush().unwrap();
         let mut input = String::new();
@@ -21,14 +21,15 @@ impl GameInterface for CLIInterface {
         let row_char = input.chars().next().unwrap();
         let row = row_char as usize - b'A' as usize;
         let col = input[1..].parse::<usize>().unwrap_or(1);
-        if row >= battleship_core::constants::GRID_SIZE || col == 0 || col > battleship_core::constants::GRID_SIZE {
+        let size = board.grid_size();
+        if row >= size || col == 0 || col > size {
             (0, 0)
         } else {
             (row, col - 1)
         }
     }
 
-    fn display_board(&self, board: &Board) {
+    fn display_board(&self, board: &dyn BoardView) {
         println!("{}", board);
     }
 
@@ -38,7 +39,7 @@ impl GameInterface for CLIInterface {
 }
 
 impl CLIInterface {
-    pub fn get_move_with_default(&self, _board: &Board, default: (usize, usize)) -> (usize, usize) {
+    pub fn get_move_with_default(&self, board: &dyn BoardView, default: (usize, usize)) -> (usize, usize) {
         let row_char = (b'A' + default.0 as u8) as char;
         let col = default.1 + 1;
         print!("Enter your move (e.g., {}{}): ", row_char, col);
@@ -55,7 +56,8 @@ impl CLIInterface {
         let row_char = input.chars().next().unwrap();
         let row = row_char as usize - b'A' as usize;
         let col = input[1..].parse::<usize>().unwrap_or(1);
-        if row >= battleship_core::constants::GRID_SIZE || col == 0 || col > battleship_core::constants::GRID_SIZE {
+        let size = board.grid_size();
+        if row >= size || col == 0 || col > size {
             (0, 0)
         } else {
             (row, col - 1)

--- a/battleship-interface/src/embedded.rs
+++ b/battleship-interface/src/embedded.rs
@@ -1,4 +1,4 @@
-use battleship_core::Board;
+use battleship_common::BoardView;
 use crate::GameInterface;
 
 /// Stub implementation of a user interface for embedded targets.
@@ -8,11 +8,11 @@ use crate::GameInterface;
 pub struct EmbeddedInterface;
 
 impl GameInterface for EmbeddedInterface {
-    fn get_move(&self, _board: &Board) -> (usize, usize) {
+    fn get_move(&self, _board: &dyn BoardView) -> (usize, usize) {
         (0, 0) // Replace with embedded-specific logic.
     }
 
-    fn display_board(&self, _board: &Board) {
+    fn display_board(&self, _board: &dyn BoardView) {
         // Embedded display logic.
     }
 

--- a/battleship-interface/src/lib.rs
+++ b/battleship-interface/src/lib.rs
@@ -1,4 +1,4 @@
-use battleship_core::Board;
+use battleship_common::BoardView;
 
 /// Abstraction over user interaction for the Battleship game.
 ///
@@ -10,10 +10,10 @@ pub trait GameInterface {
     ///
     /// The implementation is responsible for validating and parsing
     /// any user input into board coordinates.
-    fn get_move(&self, board: &Board) -> (usize, usize);
+    fn get_move(&self, board: &dyn BoardView) -> (usize, usize);
 
     /// Render the current state of the provided board to the user.
-    fn display_board(&self, board: &Board);
+    fn display_board(&self, board: &dyn BoardView);
 
     /// Show an informational message to the player.
     fn display_message(&self, message: &str);

--- a/battleship-player/Cargo.toml
+++ b/battleship-player/Cargo.toml
@@ -8,6 +8,7 @@ async-trait = "0.1"
 battleship-core = { path = "../battleship-core" }
 battleship-interface = { path = "../battleship-interface" }
 battleship-transport = { path = "../battleship-transport" }
+battleship-common = { path = "../battleship-common" }
 rand = "0.8"
 rayon = "1"
 


### PR DESCRIPTION
## Summary
- add `BoardView` trait in `battleship-common` and implement for `Board`
- update interface crate to use `BoardView`
- adapt CLI to query board size through the trait
- generalise player abstractions over `BoardView`

## Testing
- `cargo check --workspace`
- `cargo test --workspace --lib`


------
https://chatgpt.com/codex/tasks/task_e_6859bbbb55ec83299521793afd4f3a52