### PR TITLE
Fix BoardView trait visibility

### DIFF
--- a/battleship-common/src/board.rs
+++ b/battleship-common/src/board.rs
@@ -1,3 +1,0 @@
-pub trait BoardView: std::fmt::Display {
-    fn grid_size(&self) -> usize;
-}

--- a/battleship-common/src/lib.rs
+++ b/battleship-common/src/lib.rs
@@ -1,5 +1,15 @@
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
-pub mod board;
+pub mod board {
+    /// Trait representing a read-only view of a game board.
+    ///
+    /// Implementors should provide a textual display via [`std::fmt::Display`]
+    /// and report the board's dimensions through [`grid_size`].
+    pub trait BoardView: std::fmt::Display {
+        /// Return the length of one side of the square board.
+        fn grid_size(&self) -> usize;
+    }
+}
+
 pub use board::BoardView;
 


### PR DESCRIPTION
## Summary
- inline `BoardView` trait into `battleship-common` crate
- remove standalone `board.rs`

## Testing
- `cargo check -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859d785f3d88329b8b27e651ec39321