### PR TITLE
Fix GuessResult import

### DIFF
--- a/battleship-core/src/constants.rs
+++ b/battleship-core/src/constants.rs
@@ -1,27 +1,5 @@
 // Constants related to the game configuration
 
-use std::fmt;
-
-/// Represents the result of a guess attempt
-#[derive(Debug, PartialEq)]
-pub enum GuessResult {
-    /// Shot missed any ships
-    Miss,
-    /// Shot hit a ship but didn't sink it
-    Hit,
-    /// Shot hit and sunk a ship (includes ship name)
-    Sunk(&'static str),
-}
-
-impl fmt::Display for GuessResult {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            GuessResult::Miss => write!(f, "Miss"),
-            GuessResult::Hit => write!(f, "Hit"),
-            GuessResult::Sunk(s) => write!(f, "The {} was sunk!", s),
-        }
-    }
-}
 
 /// Represents possible errors during guess attempts
 #[derive(Debug)]

--- a/battleship-core/src/lib.rs
+++ b/battleship-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ship;
 pub use battleship_common::BoardView;
 pub use battleship_config::{GRID_SIZE, SHIPS};
 pub use board::Board;
-pub use constants::{Cell, GameplayError, GuessError, GuessResult, PlayerState};
+pub use constants::{Cell, GameplayError, GuessError, PlayerState};
+pub use battleship_common::GuessResult;
 pub use fleet::Fleet;
 pub use ship::Ship;

--- a/battleship-player/src/lib.rs
+++ b/battleship-player/src/lib.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use battleship_common::BoardView;
-use battleship_core::{Board, GuessResult};
+use battleship_core::Board;
+use battleship_common::GuessResult;
 use battleship_interface::GameInterface;
 use battleship_transport::Transport;
 


### PR DESCRIPTION
## Summary
- remove duplicate GuessResult enum from `battleship-core`
- export the common GuessResult type from core and use it in player crate

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859df20b9748329a62532b4d341e5c9