### PR TITLE
Fix GuessResult re-export

### DIFF
--- a/battleship-core/src/board.rs
+++ b/battleship-core/src/board.rs
@@ -1,7 +1,7 @@
 use crate::constants::Cell;
 use crate::constants::GameplayError;
 use crate::constants::GuessError;
-use battleship_common::GuessResult;
+use crate::GuessResult;
 use crate::constants::PlayerState;
 use crate::fleet::Fleet;
 use crate::ship::Ship;

--- a/battleship-core/src/fleet.rs
+++ b/battleship-core/src/fleet.rs
@@ -2,12 +2,12 @@ use std::collections::HashSet;
 
 use crate::constants::GameplayError;
 use crate::constants::GuessError;
-use battleship_common::GuessResult;
+use crate::GuessResult;
 
 use battleship_config::SHIPS;
 
 use crate::constants::GameplayError::ShipNotFound;
-use battleship_common::GuessResult::{Hit, Miss, Sunk};
+use crate::GuessResult::{Hit, Miss, Sunk};
 use crate::ship::Ship;
 
 use array_init::array_init;

--- a/battleship-core/src/lib.rs
+++ b/battleship-core/src/lib.rs
@@ -7,6 +7,6 @@ pub use battleship_common::BoardView;
 pub use battleship_config::{GRID_SIZE, SHIPS};
 pub use board::Board;
 pub use constants::{Cell, GameplayError, GuessError, PlayerState};
-pub use battleship_common::GuessResult;
+pub use battleship_common::GuessResult as GuessResult;
 pub use fleet::Fleet;
 pub use ship::Ship;

--- a/battleship-core/src/ship.rs
+++ b/battleship-core/src/ship.rs
@@ -1,7 +1,7 @@
 use crate::constants::GameplayError;
 use crate::constants::GameplayError::InvalidPlacement;
 use crate::constants::GuessError;
-use battleship_common::GuessResult;
+use crate::GuessResult;
 use std::collections::HashSet;
 
 /// Represents a single ship in the Battleship game.


### PR DESCRIPTION
## Summary
- update re-export syntax for `GuessResult`

## Testing
- `cargo build --quiet`
- `cargo test --all --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6859f2a422b4832986862b1c8088b2c6