### PR TITLE
Move GuessResult enum to core crate

### DIFF
--- a/battleship-common/src/lib.rs
+++ b/battleship-common/src/lib.rs
@@ -12,25 +12,3 @@ pub mod board {
 }
 
 pub use board::BoardView;
-
-/// Result of a guess on the game board.
-#[derive(Debug, PartialEq)]
-pub enum GuessResult {
-    /// Shot missed all ships.
-    Miss,
-    /// Shot hit a ship but didn't sink it.
-    Hit,
-    /// Shot hit and sunk a ship (includes ship name).
-    Sunk(&'static str),
-}
-
-impl std::fmt::Display for GuessResult {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GuessResult::Miss => write!(f, "Miss"),
-            GuessResult::Hit => write!(f, "Hit"),
-            GuessResult::Sunk(name) => write!(f, "The {} was sunk!", name),
-        }
-    }
-}
-

--- a/battleship-core/src/board.rs
+++ b/battleship-core/src/board.rs
@@ -1,10 +1,10 @@
 use crate::constants::Cell;
 use crate::constants::GameplayError;
 use crate::constants::GuessError;
-use crate::GuessResult;
 use crate::constants::PlayerState;
 use crate::fleet::Fleet;
 use crate::ship::Ship;
+use crate::GuessResult;
 use battleship_config::GRID_SIZE;
 use rand::{seq::IteratorRandom, thread_rng, Rng};
 use std::collections::HashSet;
@@ -246,8 +246,7 @@ impl Board {
     ///
     /// # Example
     /// ```
-    /// use battleship_core::Board;
-    /// use battleship_common::GuessResult;
+    /// use battleship_core::{Board, GuessResult};
     /// let mut board = Board::new();
     /// board.place_ship("Carrier", (0, 0), true).unwrap();
     /// let result = board.guess((0, 0));

--- a/battleship-core/src/constants.rs
+++ b/battleship-core/src/constants.rs
@@ -1,5 +1,25 @@
 // Constants related to the game configuration
 
+/// Result of a guess on the game board.
+#[derive(Debug, PartialEq)]
+pub enum GuessResult {
+    /// Shot missed all ships.
+    Miss,
+    /// Shot hit a ship but didn't sink it.
+    Hit,
+    /// Shot hit and sunk a ship (includes ship name).
+    Sunk(&'static str),
+}
+
+impl std::fmt::Display for GuessResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GuessResult::Miss => write!(f, "Miss"),
+            GuessResult::Hit => write!(f, "Hit"),
+            GuessResult::Sunk(name) => write!(f, "The {} was sunk!", name),
+        }
+    }
+}
 
 /// Represents possible errors during guess attempts
 #[derive(Debug)]

--- a/battleship-core/src/lib.rs
+++ b/battleship-core/src/lib.rs
@@ -6,7 +6,6 @@ pub mod ship;
 pub use battleship_common::BoardView;
 pub use battleship_config::{GRID_SIZE, SHIPS};
 pub use board::Board;
-pub use constants::{Cell, GameplayError, GuessError, PlayerState};
-pub use battleship_common::GuessResult as GuessResult;
+pub use constants::{Cell, GameplayError, GuessError, GuessResult, PlayerState};
 pub use fleet::Fleet;
 pub use ship::Ship;

--- a/battleship-core/src/ship.rs
+++ b/battleship-core/src/ship.rs
@@ -79,8 +79,7 @@ impl Ship {
     ///
     /// # Examples
     /// ```
-    /// use battleship_core::Ship;
-    /// use battleship_common::GuessResult;
+    /// use battleship_core::{Ship, GuessResult};
     /// use std::collections::HashSet;
     /// let mut ship = Ship::new("Destroyer", 2);
     /// ship.place(HashSet::from([(0,0), (0,1)])).unwrap();

--- a/battleship-player/src/lib.rs
+++ b/battleship-player/src/lib.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
 use battleship_common::BoardView;
-use battleship_core::Board;
-use battleship_common::GuessResult;
+use battleship_core::{Board, GuessResult};
 use battleship_interface::GameInterface;
 use battleship_transport::Transport;
 
-pub mod probability;
 pub mod posterior;
+pub mod probability;
 
 /// Core player trait used by the game engine.
 #[async_trait]
@@ -21,7 +20,9 @@ pub struct HumanPlayer<I: GameInterface> {
 }
 
 impl<I: GameInterface> HumanPlayer<I> {
-    pub fn new(interface: I) -> Self { Self { interface } }
+    pub fn new(interface: I) -> Self {
+        Self { interface }
+    }
 }
 
 #[async_trait]
@@ -58,7 +59,9 @@ pub struct RemotePlayer<I: GameInterface, T: Transport> {
 }
 
 impl<I: GameInterface, T: Transport> RemotePlayer<I, T> {
-    pub fn new(iface: I, transport: T) -> Self { Self { iface, transport } }
+    pub fn new(iface: I, transport: T) -> Self {
+        Self { iface, transport }
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary
- host `GuessResult` in `battleship-core` instead of `battleship-common`
- update exports in `battleship-core`
- fix imports and docs referring to the enum

## Testing
- `cargo test --workspace --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6859f9c184a88329ab1caf0e3809b1b7