### PR TITLE
Fix compile errors, update deps

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,12 +4,13 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-core = { path = "../core" }
+battleship_core = { package = "core", path = "../core" }
+async-trait = "0.1"
 transport = { path = "../transport" }
 interface-cli = { path = "../interface-cli" }
 persistence = { path = "../persistence" }
 player = { path = "../player" }
-clap = "4.0"
+clap = "3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["full"] }

--- a/app/src/placement.rs
+++ b/app/src/placement.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
-use crate::transport::ReliableTransport;
-use core::state::{GameState, PlayerId, Phase, Orientation};
-use core::ship::ShipType;
-use core::message::Message;
+use transport::ReliableTransport;
+use battleship_core::state::{GameState, PlayerId, Phase, Orientation};
+use battleship_core::ship::ShipType;
+use battleship_core::message::Message;
 use interface_cli::{InputProvider, OutputRenderer, InputEvent};
 use std::io;
 
@@ -14,7 +14,7 @@ pub async fn run_placement<T, I, O>(
     local_id: PlayerId,
 ) -> io::Result<()>
 where
-    T: crate::transport::RawTransport<Error = io::Error> + Send,
+    T: transport::RawTransport + Send,
     I: InputProvider + Send + Sync,
     O: OutputRenderer + Send + Sync,
 {
@@ -42,7 +42,7 @@ where
 }
 
 // Simple in-mem peer for testing:
-pub async fn run_peer<T: crate::transport::RawTransport<Error = io::Error> + Send + 'static>(mut transport: ReliableTransport<T>) {
+pub async fn run_peer<T: transport::RawTransport + Send + 'static>(mut transport: ReliableTransport<T>) {
     let mut state = GameState::new(10,10);
     let local = PlayerId::Two;
     transport.recv().await.unwrap(); // handshake

--- a/core/src/board.rs
+++ b/core/src/board.rs
@@ -1,10 +1,9 @@
-use crate::constants::{BOARD_WIDTH, BOARD_HEIGHT};
+use serde::{Serialize, Deserialize};
 use crate::state::Orientation;
-use crate::fleet::Fleet;
 use crate::ship::ShipType;
 use crate::state::Cell;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Board {
     pub width: u8,
     pub height: u8,
@@ -55,6 +54,6 @@ impl Board {
         matches!(self.idx(x,y).and_then(|i| Some(self.cells[i])), Some(Cell::Empty)|Some(Cell::Ship(_)))
     }
     pub fn all_sunk(&self) -> bool {
-        self.ships.iter().all(|s| s.hits >= s.length)
+        self.ships.iter().all(|s| s.hits >= s.length as usize)
     }
 }

--- a/core/src/ship.rs
+++ b/core/src/ship.rs
@@ -1,4 +1,3 @@
-use crate::state::Orientation;
 use serde::{Serialize, Deserialize};
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -16,7 +15,7 @@ impl ShipType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Ship {
     pub ship_type: ShipType,
     pub positions: Vec<(u8,u8)>,

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -5,7 +5,7 @@ use crate::ship::ShipType;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum Phase { Handshake, Placement, Playing, Finished }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum PlayerId { One, Two }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -22,22 +22,25 @@ impl GameState {
             turn: PlayerId::One, phase: Phase::Handshake }
     }
     pub fn receive_attack(&mut self, attacker: PlayerId, x: u8, y: u8) -> (bool, Option<ShipType>) {
-        let (board, ships) = match attacker {
-            PlayerId::One => (&mut self.board_p2, &mut self.board_p2.ships),
-            PlayerId::Two => (&mut self.board_p1, &mut self.board_p1.ships),
+        let board = match attacker {
+            PlayerId::One => &mut self.board_p2,
+            PlayerId::Two => &mut self.board_p1,
         };
         if let Some(idx) = board.grid_index(x,y) {
             let cell = &mut board.cells[idx];
             if let crate::state::Cell::Ship(id) = *cell {
                 *cell = crate::state::Cell::Hit;
-                let ship = &mut ships[id as usize];
-                ship.hits += 1;
-                if ship.hits >= ship.length {
-                    for &(sx,sy) in &ship.positions {
+                let (ship_type, positions, sunk) = {
+                    let ship = &mut board.ships[id as usize];
+                    ship.hits += 1;
+                    (ship.ship_type, ship.positions.clone(), ship.hits >= ship.length as usize)
+                };
+                if sunk {
+                    for &(sx,sy) in &positions {
                         let i = board.grid_index(sx,sy).unwrap();
                         board.cells[i] = crate::state::Cell::Sunk;
                     }
-                    return (true, Some(ship.ship_type));
+                    return (true, Some(ship_type));
                 }
                 return (true, None);
             } else {

--- a/interface-cli/Cargo.toml
+++ b/interface-cli/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
+battleship_core = { package = "core", path = "../core" }

--- a/interface-cli/src/lib.rs
+++ b/interface-cli/src/lib.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
-use core::state::GameState;
-use core::message::Message;
-use crate::state::Orientation;
+use battleship_core::state::{GameState, Orientation};
+use battleship_core::message::Message;
 use std::io::{self, Write};
 
 #[async_trait]

--- a/interface-embedded/Cargo.toml
+++ b/interface-embedded/Cargo.toml
@@ -2,3 +2,7 @@
 name = "interface-embedded"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+battleship_core = { package = "core", path = "../core" }
+interface-cli = { path = "../interface-cli" }

--- a/interface-embedded/src/lib.rs
+++ b/interface-embedded/src/lib.rs
@@ -1,11 +1,10 @@
 // Stub for embedded interface
-use crate::state::Orientation;
-use core::state::GameState;
-use crate::message::Message;
+use battleship_core::state::GameState;
+use battleship_core::message::Message;
 
 pub struct EmbeddedInput;
 impl EmbeddedInput { pub fn new() -> Self { EmbeddedInput } }
-impl EmbeddedInput { pub fn read_buttons(&self) -> super::interface_cli::InputEvent { unimplemented!() } }
+impl EmbeddedInput { pub fn read_buttons(&self) -> interface_cli::InputEvent { unimplemented!() } }
 
 pub struct EmbeddedDisplay;
 impl EmbeddedDisplay { pub fn new() -> Self { EmbeddedDisplay } }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-core = { path = "../core" }
+battleship_core = { package = "core", path = "../core" }

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -2,7 +2,7 @@ use serde_json;
 use std::fs;
 use std::io;
 use std::path::Path;
-use crate::state::GameState;
+use battleship_core::state::GameState;
 
 pub trait Persistence {
     fn save(&self, state: &GameState, path: &Path) -> io::Result<()>;

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-core = { path = "../core" }
+battleship_core = { package = "core", path = "../core" }
 interface-cli = { path = "../interface-cli" }

--- a/player/src/ai.rs
+++ b/player/src/ai.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use core::state::{GameState, PlayerId};
-use core::probability::{ProbabilityEngine, ProbabilityGrid};
+use battleship_core::state::{GameState, PlayerId};
+use battleship_core::probability::{ProbabilityEngine, ProbabilityGrid};
 use crate::Move;
 
 #[derive(Clone, Copy)]

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -2,7 +2,7 @@ mod ai;
 pub use ai::{ProbAi, Difficulty};
 
 use async_trait::async_trait;
-use core::state::GameState;
+use battleship_core::state::GameState;
 use interface_cli::{InputProvider, OutputRenderer, InputEvent};
 
 #[derive(Clone, Copy, Debug)]

--- a/transport/Cargo.toml
+++ b/transport/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
 tokio = { version = "1", features = ["sync", "net", "time"] }
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
-core = { path = "../core" }
+battleship_core = { package = "core", path = "../core" }

--- a/transport/src/adapters.rs
+++ b/transport/src/adapters.rs
@@ -20,11 +20,10 @@ impl InMemTransport {
 
 #[async_trait]
 impl RawTransport for InMemTransport {
-    type Error = io::Error;
-    async fn send_bytes(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+    async fn send_bytes(&mut self, data: &[u8]) -> io::Result<()> {
         self.tx.send(data.to_vec()).await.map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "dropped"))
     }
-    async fn recv_bytes(&mut self) -> Result<Vec<u8>, Self::Error> {
+    async fn recv_bytes(&mut self) -> io::Result<Vec<u8>> {
         self.rx.recv().await.ok_or(io::Error::new(io::ErrorKind::UnexpectedEof, "closed"))
     }
 }
@@ -37,14 +36,13 @@ impl TcpTransport {
 
 #[async_trait]
 impl RawTransport for TcpTransport {
-    type Error = io::Error;
-    async fn send_bytes(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+    async fn send_bytes(&mut self, data: &[u8]) -> io::Result<()> {
         let len = data.len() as u32;
         self.stream.write_u32_le(len).await?;
         self.stream.write_all(data).await?;
         Ok(())
     }
-    async fn recv_bytes(&mut self) -> Result<Vec<u8>, Self::Error> {
+    async fn recv_bytes(&mut self) -> io::Result<Vec<u8>> {
         let len = self.stream.read_u32_le().await?;
         let mut buf = vec![0; len as usize];
         self.stream.read_exact(&mut buf).await?;
@@ -55,7 +53,6 @@ impl RawTransport for TcpTransport {
 pub struct BtleTransport;
 #[async_trait]
 impl RawTransport for BtleTransport {
-    type Error = io::Error;
-    async fn send_bytes(&mut self, _data: &[u8]) -> Result<(), Self::Error> { unimplemented!() }
-    async fn recv_bytes(&mut self) -> Result<Vec<u8>, Self::Error> { unimplemented!() }
+    async fn send_bytes(&mut self, _data: &[u8]) -> io::Result<()> { unimplemented!() }
+    async fn recv_bytes(&mut self) -> io::Result<Vec<u8>> { unimplemented!() }
 }


### PR DESCRIPTION
## Summary
- derive serde traits for Board and Ship
- update GameState logic to avoid borrow checker issues
- adjust crate dependencies to avoid conflicts with std `core`
- implement transport trait object support and update transports
- tweak app to compile with new transport changes

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_685a1cc5fc808329862dba9ce074bcae