### PR TITLE
Fix board serialization & adjust imports

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-core = { path = "../core" }
+game-core = { path = "../core" }
 transport = { path = "../transport" }
 interface-cli = { path = "../interface-cli" }
 persistence = { path = "../persistence" }

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -6,8 +6,8 @@ use tokio::net::TcpListener;
 use tokio::io;
 use std::path::Path;
 
-use core::{GameState, PlayerId, Phase};
-use core::message::Message;
+use game_core::{GameState, PlayerId, Phase};
+use game_core::message::Message;
 use transport::{RawTransport, ReliableTransport};
 use transport::adapters::{InMemTransport, TcpTransport, BtleTransport};
 use persistence::JsonPersistence;
@@ -59,7 +59,7 @@ async fn main() -> io::Result<()> {
         mode, addr, buffer, width, height, layout_path);
 
     let mut state = if let Some(path) = layout_path {
-        core::layout::ShipLayout::apply
+        game_core::layout::ShipLayout::apply
     GameState::from_file(path, width, height).unwrap_or_else(|_| GameState::new(width, height))
     } else {
         GameState::new(width, height)

--- a/app/src/placement.rs
+++ b/app/src/placement.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use crate::transport::ReliableTransport;
-use core::state::{GameState, PlayerId, Phase, Orientation};
-use core::ship::ShipType;
-use core::message::Message;
+use game_core::state::{GameState, PlayerId, Phase, Orientation};
+use game_core::ship::ShipType;
+use game_core::message::Message;
 use interface_cli::{InputProvider, OutputRenderer, InputEvent};
 use std::io;
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
-name = "core"
+name = "game-core"
 version = "0.1.0"
 edition = "2021"
+
+[lib]
+name = "game_core"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/core/src/board.rs
+++ b/core/src/board.rs
@@ -1,10 +1,9 @@
-use crate::constants::{BOARD_WIDTH, BOARD_HEIGHT};
 use crate::state::Orientation;
-use crate::fleet::Fleet;
 use crate::ship::ShipType;
 use crate::state::Cell;
+use serde::{Serialize, Deserialize};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Board {
     pub width: u8,
     pub height: u8,
@@ -55,6 +54,6 @@ impl Board {
         matches!(self.idx(x,y).and_then(|i| Some(self.cells[i])), Some(Cell::Empty)|Some(Cell::Ship(_)))
     }
     pub fn all_sunk(&self) -> bool {
-        self.ships.iter().all(|s| s.hits >= s.length)
+        self.ships.iter().all(|s| s.hits >= usize::from(s.length))
     }
 }

--- a/core/src/ship.rs
+++ b/core/src/ship.rs
@@ -1,4 +1,3 @@
-use crate::state::Orientation;
 use serde::{Serialize, Deserialize};
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -16,7 +15,7 @@ impl ShipType {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Ship {
     pub ship_type: ShipType,
     pub positions: Vec<(u8,u8)>,

--- a/core/src/state.rs
+++ b/core/src/state.rs
@@ -5,7 +5,7 @@ use crate::ship::ShipType;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum Phase { Handshake, Placement, Playing, Finished }
 
-#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum PlayerId { One, Two }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -22,22 +22,25 @@ impl GameState {
             turn: PlayerId::One, phase: Phase::Handshake }
     }
     pub fn receive_attack(&mut self, attacker: PlayerId, x: u8, y: u8) -> (bool, Option<ShipType>) {
-        let (board, ships) = match attacker {
-            PlayerId::One => (&mut self.board_p2, &mut self.board_p2.ships),
-            PlayerId::Two => (&mut self.board_p1, &mut self.board_p1.ships),
+        let board = match attacker {
+            PlayerId::One => &mut self.board_p2,
+            PlayerId::Two => &mut self.board_p1,
         };
         if let Some(idx) = board.grid_index(x,y) {
             let cell = &mut board.cells[idx];
             if let crate::state::Cell::Ship(id) = *cell {
                 *cell = crate::state::Cell::Hit;
-                let ship = &mut ships[id as usize];
+                let ship = &mut board.ships[id as usize];
                 ship.hits += 1;
-                if ship.hits >= ship.length {
-                    for &(sx,sy) in &ship.positions {
+                if ship.hits >= usize::from(ship.length) {
+                    let positions = ship.positions.clone();
+                    let ship_type = ship.ship_type;
+                    drop(ship);
+                    for &(sx,sy) in &positions {
                         let i = board.grid_index(sx,sy).unwrap();
                         board.cells[i] = crate::state::Cell::Sunk;
                     }
-                    return (true, Some(ship.ship_type));
+                    return (true, Some(ship_type));
                 }
                 return (true, None);
             } else {

--- a/interface-cli/Cargo.toml
+++ b/interface-cli/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
+game-core = { path = "../core" }

--- a/interface-cli/src/lib.rs
+++ b/interface-cli/src/lib.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
-use core::state::GameState;
-use core::message::Message;
-use crate::state::Orientation;
+use game_core::state::{GameState, Orientation};
+use game_core::message::Message;
 use std::io::{self, Write};
 
 #[async_trait]

--- a/interface-embedded/Cargo.toml
+++ b/interface-embedded/Cargo.toml
@@ -2,3 +2,7 @@
 name = "interface-embedded"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+game-core = { path = "../core" }
+interface-cli = { path = "../interface-cli" }

--- a/interface-embedded/src/lib.rs
+++ b/interface-embedded/src/lib.rs
@@ -1,11 +1,11 @@
 // Stub for embedded interface
-use crate::state::Orientation;
-use core::state::GameState;
-use crate::message::Message;
+use game_core::state::{GameState, Orientation};
+use game_core::message::Message;
+use interface_cli::InputEvent;
 
 pub struct EmbeddedInput;
 impl EmbeddedInput { pub fn new() -> Self { EmbeddedInput } }
-impl EmbeddedInput { pub fn read_buttons(&self) -> super::interface_cli::InputEvent { unimplemented!() } }
+impl EmbeddedInput { pub fn read_buttons(&self) -> InputEvent { unimplemented!() } }
 
 pub struct EmbeddedDisplay;
 impl EmbeddedDisplay { pub fn new() -> Self { EmbeddedDisplay } }

--- a/persistence/Cargo.toml
+++ b/persistence/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-core = { path = "../core" }
+game-core = { path = "../core" }

--- a/persistence/src/lib.rs
+++ b/persistence/src/lib.rs
@@ -2,7 +2,7 @@ use serde_json;
 use std::fs;
 use std::io;
 use std::path::Path;
-use crate::state::GameState;
+use game_core::state::GameState;
 
 pub trait Persistence {
     fn save(&self, state: &GameState, path: &Path) -> io::Result<()>;

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-core = { path = "../core" }
+game-core = { path = "../core" }
 interface-cli = { path = "../interface-cli" }

--- a/player/src/ai.rs
+++ b/player/src/ai.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use core::state::{GameState, PlayerId};
-use core::probability::{ProbabilityEngine, ProbabilityGrid};
+use game_core::state::{GameState, PlayerId};
+use game_core::probability::{ProbabilityEngine, ProbabilityGrid};
 use crate::Move;
 
 #[derive(Clone, Copy)]

--- a/player/src/lib.rs
+++ b/player/src/lib.rs
@@ -2,7 +2,7 @@ mod ai;
 pub use ai::{ProbAi, Difficulty};
 
 use async_trait::async_trait;
-use core::state::GameState;
+use game_core::state::GameState;
 use interface_cli::{InputProvider, OutputRenderer, InputEvent};
 
 #[derive(Clone, Copy, Debug)]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,8 +1,8 @@
 use tokio::runtime::Runtime;
 use transport::adapters::InMemTransport;
 use transport::ReliableTransport;
-use core::{GameState, PlayerId};
-use core::message::Message;
+use game_core::{GameState, PlayerId};
+use game_core::message::Message;
 use player::ProbAi;
 use player::Difficulty;
 


### PR DESCRIPTION
## Summary
- derive `Serialize`/`Deserialize` for `Board` and `Ship`
- fix player ID move and length comparisons in `GameState`
- rename core crate to `game-core` and update imports
- clean up interface crates after rename

## Testing
- `cargo check -p game-core`
- `cargo check -p interface-cli`
- `cargo check -p interface-embedded`
- `cargo check -p player`
- `cargo check -p persistence`


------
https://chatgpt.com/codex/tasks/task_e_685a1cc5fc808329862dba9ce074bcae